### PR TITLE
Fix/react rerenders

### DIFF
--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -22,7 +22,7 @@ Swiperia is a powerful and flexible library for creating smooth and responsive s
   ```
   then you can import the components you need:
   ```jsx copy
-  import { useSwiperia } from 'swiperia-react';
+  import { useSwiperia, SwipeCallback } from 'swiperia-react';
 
 const App = () => {
   const { ref } = useSwiperia({

--- a/docs/src/pages/react/swipe-area.mdx
+++ b/docs/src/pages/react/swipe-area.mdx
@@ -1,10 +1,10 @@
 #### Overview
 
-The `SwipeArea` component is a versatile React component designed to facilitate swipe gesture detection and handling within a React application. It leverages the `useSwiperia` hook from the `swiperia-react` library to provide a seamless integration of swipe functionalities. This component wraps any child content and automatically manages swipe gestures, making it ideal for implementing interactive, touch-responsive elements.
+The `SwipeArea` component is a versatile React component designed to facilitate swipe gesture detection and handling within a React application. It leverages the `useSwiperia` hook from the `swiperia-react` library to provide a seamless integration of swipe functionalities. This component wraps any child content and automatically manages swipe gestures, making it ideal for implementing interactive, touch-responsive elements.
 
 #### Props
 
-The `SwipeArea` component accepts all standard swipe event callbacks provided by the `swiperia-react` library, along with all standard properties of a `div` element. Here are the specific swipe-related props it supports:
+The `SwipeArea` component accepts all standard swipe event callbacks provided by the `swiperia-react` library, along with all standard properties of a `div` element. Here are the specific swipe-related props it supports:
 
 * **onSwipeStart**: Function called at the start of a swipe gesture.
 * **onSwiped**: Function called when a swipe gesture is completed.
@@ -13,16 +13,17 @@ The `SwipeArea` component accepts all standard swipe event callbacks provided 
 * **onSwipedRight**: Function called specifically when a swipe right gesture is completed.
 * **onSwipedUp**: Function called specifically when a swipe up gesture is completed.
 * **onSwiping**: Function called with each movement during an active swipe gesture.
+* **onSwipeCancelled**: Function called when the swipe is cancelled.
 
 These callbacks provide a way to respond to different phases and directions of swipe gestures, allowing for detailed interaction design within your application.
 
 #### Usage
 
-Here is a basic example of how to use the `SwipeArea` component:
+Here is a basic example of how to use the `SwipeArea` component:
 
 ```jsx
 import React from 'react';
-import SwipeArea from 'swiperia-react';
+import { SwipeArea, SwipeCallback } from 'swiperia-react';
 
 const MySwipeableComponent = () => {
   return (
@@ -42,8 +43,8 @@ export default MySwipeableComponent;
 
 #### Integration Details
 
-* **Ref Forwarding**: The `SwipeArea` component forwards a ref to the underlying div element. This is useful for managing focus, animations, or direct DOM manipulation.
-* **Combining with other props**: All other props not related to swipe functionalities (like `className`, `style`, etc.) are passed down to the root div element. This makes it easy to style and position the `SwipeArea` as needed.
+* **Ref Forwarding**: The `SwipeArea` component forwards a ref to the underlying div element. This is useful for managing focus, animations, or direct DOM manipulation.
+* **Combining with other props**: All other props not related to swipe functionalities (like `className`, `style`, etc.) are passed down to the root div element. This makes it easy to style and position the `SwipeArea` as needed.
 
 #### Best Practices
 

--- a/docs/src/pages/react/use-swiperia.mdx
+++ b/docs/src/pages/react/use-swiperia.mdx
@@ -14,6 +14,7 @@ const MyComponent = () => {
     onSwipedRight: event => console.log('Swiped right', event),
     onSwipedUp: event => console.log('Swiped up', event),
     onSwipedDown: event => console.log('Swiped down', event),
+    onSwipeCancelled: event => console.log('Swipe cancelled', event),
   });
 
   return <div ref={ref}>Swipe here</div>;
@@ -31,6 +32,7 @@ const MyComponent = () => {
     * `onSwipeStart?`: Called when a swipe action starts.
     * `onSwiping?`: Called during a swipe action.
     * `onSwipedLeft?`, `onSwipedRight?`, `onSwipedUp?`, `onSwipedDown?`: Called when a swipe action completes in the respective direction.
+    * `onSwipeCancelled?`: Called when the swipe is cancelled.
 
 #### Returns
 
@@ -57,6 +59,7 @@ const SwipeableComponent = () => {
     onSwiped: (event) => alert(`Swiped ${event.direction}`),
     onSwipeStart: () => console.log('Swipe started'),
     onSwiping: (event) => console.log(`Swiping in direction: ${event.direction}`),
+    onSwipeCancelled: () => console.log('Swipe cancelled'),
   });
 
   return <div ref={ref} style={{ width: '100%', height: '300px', backgroundColor: '#ccc' }}>

--- a/packages/swiperia-react/package.json
+++ b/packages/swiperia-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swiperia-react",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "type": "module",
   "description": "Swiperia React: A powerful suite of JavaScript libraries for building intuitive swipe-driven user interfaces. Provides core gesture handling, web-specific implementations, and React components for seamless integration.",
   "license": "MIT",

--- a/packages/swiperia-react/src/index.ts
+++ b/packages/swiperia-react/src/index.ts
@@ -7,3 +7,5 @@ export {
   default as SwipeArea,
   type SwipeAreaProps,
 } from './lib/SwipeArea/SwipeArea';
+
+export * from './lib/types';

--- a/packages/swiperia-react/src/lib/SwipeArea/SwipeArea.tsx
+++ b/packages/swiperia-react/src/lib/SwipeArea/SwipeArea.tsx
@@ -20,6 +20,7 @@ const SwipeArea = forwardRef<HTMLDivElement, SwipeAreaProps>(
       onSwipedRight,
       onSwipedUp,
       onSwiping,
+      onSwipeCancelled,
       ...props
     },
     ref
@@ -32,6 +33,7 @@ const SwipeArea = forwardRef<HTMLDivElement, SwipeAreaProps>(
       onSwipedRight,
       onSwipedUp,
       onSwiping,
+      onSwipeCancelled,
     });
 
     const handleRef = useCallback(

--- a/packages/swiperia-react/src/lib/types.ts
+++ b/packages/swiperia-react/src/lib/types.ts
@@ -1,35 +1,41 @@
-import { SwipeCallback } from "swiperia-core";
+import { SwipeCallback } from 'swiperia-core';
+
+export type { SwipeCallback };
 
 export interface SwiperiaDirectionCallbacks {
-    /**
-     * Called after a DOWN swipe
-     */
-    onSwipedDown?: SwipeCallback;
-    /**
-     * Called after a LEFT swipe
-     */
-    onSwipedLeft?: SwipeCallback;
-    /**
-     * Called after a RIGHT swipe
-     */
-    onSwipedRight?: SwipeCallback;
-    /**
-     * Called after a UP swipe
-     */
-    onSwipedUp?: SwipeCallback;
-  }
-  
-  export interface SwiperiaCallbacks extends SwiperiaDirectionCallbacks {
-    /**
-     * Called at start of a tracked swipe.
-     */
-    onSwipeStart?: SwipeCallback;
-    /**
-     * Called after any swipe.
-     */
-    onSwiped?: SwipeCallback;
-    /**
-     * Called for each move event during a tracked swipe.
-     */
-    onSwiping?: SwipeCallback;
-  }
+  /**
+   * Called after a DOWN swipe
+   */
+  onSwipedDown?: SwipeCallback;
+  /**
+   * Called after a LEFT swipe
+   */
+  onSwipedLeft?: SwipeCallback;
+  /**
+   * Called after a RIGHT swipe
+   */
+  onSwipedRight?: SwipeCallback;
+  /**
+   * Called after a UP swipe
+   */
+  onSwipedUp?: SwipeCallback;
+}
+
+export interface SwiperiaCallbacks extends SwiperiaDirectionCallbacks {
+  /**
+   * Called at start of a tracked swipe.
+   */
+  onSwipeStart?: SwipeCallback;
+  /**
+   * Called after any swipe.
+   */
+  onSwiped?: SwipeCallback;
+  /**
+   * Called for each move event during a tracked swipe.
+   */
+  onSwiping?: SwipeCallback;
+  /**
+   * Called when the swipe is cancelled.
+   */
+  onSwipeCancelled?: SwipeCallback;
+}

--- a/packages/swiperia-react/src/lib/useSwiperia/useSwiperia.spec.ts
+++ b/packages/swiperia-react/src/lib/useSwiperia/useSwiperia.spec.ts
@@ -52,6 +52,7 @@ describe('useSwiperia', () => {
     const onSwipedUp = vi.fn();
     const onSwipeStart = vi.fn();
     const onSwiping = vi.fn();
+    const onSwipeCancelled = vi.fn();
 
     const { result } = renderHook(() =>
       useSwiperia({
@@ -62,6 +63,7 @@ describe('useSwiperia', () => {
         onSwipedUp,
         onSwipeStart,
         onSwiping,
+        onSwipeCancelled,
       })
     );
 
@@ -82,6 +84,7 @@ describe('useSwiperia', () => {
     expect(onSwipedRight).not.toHaveBeenCalled();
     expect(onSwipedUp).not.toHaveBeenCalled();
     expect(onSwipedLeft).not.toHaveBeenCalled();
+    expect(onSwipeCancelled).not.toHaveBeenCalled();
   });
 
   it('should destroy the Swiper instance on cleanup', () => {


### PR DESCRIPTION
# Export SwipeCallback Type and Add onSwipeCancelled Callback

## Changes

This PR makes the following improvements:

1. **Add `onSwipeCancelled` callback to the API**
   - New callback that triggers when a swipe gesture is cancelled
   - Provides developers with better control over the swipe lifecycle
   - Implemented in the `SwiperiaCallbacks` interface

2. **Export `SwipeCallback` type from swiperia-react package**
   - Allows consumers to directly import this type when using callbacks
   - Improves developer experience when working with TypeScript

3. **Update documentation in various files:**
   - Added documentation for the new `onSwipeCancelled` callback
   - Updated import examples to show proper usage with `SwipeCallback`
   - Ensured consistency in documentation for all callback props
   - Fixed formatting (using single quotes consistently)

4. **Enhanced test coverage:**
   - Added test case for `onSwipeCancelled` callback in `useSwiperia.spec.ts`
   - Ensures complete test coverage for all supported callbacks

## Benefits

- New callback provides more fine-grained control over swipe interactions
- Improves TypeScript support for consumers of the library
- Provides clearer examples in documentation
- Makes it easier for developers to understand and use the callback types correctly